### PR TITLE
remove dummy database reference

### DIFF
--- a/analysis/archive/localtest_getdata.R
+++ b/analysis/archive/localtest_getdata.R
@@ -18,10 +18,10 @@
 ## the dummy database connection details are as follows:
 
 driver = 'ODBC Driver 17 for SQL Server'
-server = 'covid.ebmdatalab.net,1433'
-database = 'OPENCoronaExport' 
-username = 'SA'
-password = 'ahsjdkaJAMSHDA123['
+server = 
+database = 
+
+
 
 ## convert this to a string
 dbconn_string = paste0(
@@ -29,7 +29,7 @@ dbconn_string = paste0(
   ';SERVER=',server,
   ';DATABASE=',database,
   ';UID=',username,
-  ';PWD=',password
+
 )
 
 ## 3. add this string to your environment:


### PR DESCRIPTION
In a previous iteration of the OpenSAFELY framework there was a dummy database with dummy data. This commit removes the credentials to avoid any confusion about passwords.